### PR TITLE
Allow usage of GET parameters in .get method

### DIFF
--- a/lib/knox/client.js
+++ b/lib/knox/client.js
@@ -12,6 +12,7 @@
 var utils = require('./utils')
   , auth = require('./auth')
   , http = require('http')
+  , url = require('url')
   , join = require('path').join
   , mime = require('./mime')
   , fs = require('fs');
@@ -65,7 +66,7 @@ Client.prototype.request = function(method, filename, headers){
     , secret: this.secret
     , verb: method
     , date: date
-    , resource: path
+    , resource: url.parse(path).pathname
     , contentType: headers['Content-Type']
     , amazonHeaders: auth.canonicalizeHeaders(headers)
   });


### PR DESCRIPTION
This is a patch that allows basic URL parameters to be used in knox. It's definitely just a first step, because certain URL parameters (sub-resources) should be present in the signed string, but it at least allows users to, for instance, list buckets using the marker parameter.
