### PR TITLE
extra tests derived from Amazon docs

### DIFF
--- a/lib/knox/auth.js
+++ b/lib/knox/auth.js
@@ -61,7 +61,7 @@ exports.stringToSign = function(options){
       options.verb
     , options.md5
     , options.contentType
-    , options.date.toUTCString()
+    , options.date instanceof Date ? options.date.toUTCString() : options.date
     , headers + options.resource
   ].join('\n');
 };
@@ -82,13 +82,20 @@ exports.stringToSign = function(options){
 
 exports.canonicalizeHeaders = function(headers){
   var buf = []
-    , fields = Object.keys(headers);
+    , fields = Array.isArray(headers) ? headers : Object.keys(headers)
+    , uniqueHeaders = {};
   for (var i = 0, len = fields.length; i < len; ++i) {
-    var field = fields[i]
-      , val = headers[field]
+    var field = Array.isArray(fields[i]) ? fields[i][0] : fields[i]
+      , val = Array.isArray(fields[i]) ? fields[i][1] : headers[field]
       , field = field.toLowerCase();
     if (0 !== field.indexOf('x-amz')) continue;
-    buf.push(field + ':' + val);
+    if (field in uniqueHeaders) {
+      buf[uniqueHeaders[field]] += ','+val;
+    }
+    else {
+      uniqueHeaders[field] = buf.length;
+      buf.push(field + ':' + val);
+    }
   }
   return buf.sort().join('\n');
 };

--- a/test/amzn.test.js
+++ b/test/amzn.test.js
@@ -1,0 +1,118 @@
+/**
+ * Module dependencies.
+ */
+
+var knox = require('knox')
+  , auth = knox.auth;
+
+// comparing Authentication header results for test cases from
+// http://docs.amazonwebservices.com/AmazonS3/2006-03-01/dev/index.html?RESTAuthentication.html
+
+module.exports = { 
+
+    getSign: function(assert) {
+      var str = auth.authorization({
+          verb: 'GET'
+        , key: "0PN5J17HBGZHT7JJ3X82"
+        , secret: "uV3F3YluFJax1cknvbcGwgjvx4QpvB+leU8dUj2o"
+        , resource: '/johnsmith/photos/puppy.jpg'
+        , date: 'Tue, 27 Mar 2007 19:36:42 +0000'
+      });    
+      assert.equal("AWS 0PN5J17HBGZHT7JJ3X82:xXjDGYUmKxnwqr5KXNPGldn5LbA=", str);
+    },
+
+    putSign: function(assert) {
+      var str = auth.authorization({
+          verb: 'PUT'
+        , key: "0PN5J17HBGZHT7JJ3X82"
+        , secret: "uV3F3YluFJax1cknvbcGwgjvx4QpvB+leU8dUj2o"
+        , resource: '/johnsmith/photos/puppy.jpg'
+        , contentType: 'image/jpeg'
+        , date: 'Tue, 27 Mar 2007 21:15:45 +0000'
+      });    
+      assert.equal("AWS 0PN5J17HBGZHT7JJ3X82:hcicpDDvL9SsO6AkvxqmIWkmOuQ=", str);
+    },
+    
+    listSign: function(assert) {
+      var str = auth.authorization({
+          verb: 'GET'
+        , key: "0PN5J17HBGZHT7JJ3X82"
+        , secret: "uV3F3YluFJax1cknvbcGwgjvx4QpvB+leU8dUj2o"
+        , resource: '/johnsmith/'
+        , date: 'Tue, 27 Mar 2007 19:42:41 +0000'
+      });    
+      assert.equal("AWS 0PN5J17HBGZHT7JJ3X82:jsRt/rhG+Vtp88HrYL706QhE4w4=", str);    
+    },
+
+    fetchSign: function(assert) {
+      var str = auth.authorization({
+          verb: 'GET'
+        , key: "0PN5J17HBGZHT7JJ3X82"
+        , secret: "uV3F3YluFJax1cknvbcGwgjvx4QpvB+leU8dUj2o"
+        , resource: '/johnsmith/?acl'
+        , date: 'Tue, 27 Mar 2007 19:44:46 +0000'
+      });    
+      assert.equal("AWS 0PN5J17HBGZHT7JJ3X82:thdUi9VAkzhkniLj96JIrOPGi0g=", str);
+    },
+    
+    deleteSign: function(assert) {
+      var str = auth.authorization({
+          verb: 'DELETE'
+        , key: "0PN5J17HBGZHT7JJ3X82"
+        , secret: "uV3F3YluFJax1cknvbcGwgjvx4QpvB+leU8dUj2o"
+        , amazonHeaders: auth.canonicalizeHeaders({
+            'x-amz-date': 'Tue, 27 Mar 2007 21:20:26 +0000'
+          })
+        , resource: '/johnsmith/photos/puppy.jpg'
+        // NB:- omit date if there's an x-amz-date
+      });    
+      assert.equal("AWS 0PN5J17HBGZHT7JJ3X82:k3nL7gH3+PadhTEVn5Ip83xlYzk=", str);
+    },
+
+    uploadSign: function(assert) {
+      var str = auth.authorization({
+          verb: 'PUT'
+        , key: "0PN5J17HBGZHT7JJ3X82"
+        , secret: "uV3F3YluFJax1cknvbcGwgjvx4QpvB+leU8dUj2o"
+        , contentType: 'application/x-download'
+        , md5: '4gJE4saaMU4BqNR0kLY+lw=='
+        , amazonHeaders: auth.canonicalizeHeaders([
+            [ 'x-amz-acl', 'public-read' ],
+            [ 'X-Amz-Meta-ReviewedBy', 'joe@johnsmith.net' ],
+            [ 'X-Amz-Meta-ReviewedBy', 'jane@johnsmith.net' ],
+            [ 'X-Amz-Meta-FileChecksum', '0x02661779' ],
+            [ 'X-Amz-Meta-ChecksumAlgorithm', 'crc32' ],
+          ])
+        , resource: '/static.johnsmith.net/db-backup.dat.gz'
+        , date: 'Tue, 27 Mar 2007 21:06:08 +0000'
+      });    
+      assert.equal("AWS 0PN5J17HBGZHT7JJ3X82:C0FlOtU8Ylb9KDTpZqYkZPX91iI=", str);
+    },
+
+    listBucketSign: function(assert) {
+      var str = auth.authorization({
+          verb: 'GET'
+        , key: "0PN5J17HBGZHT7JJ3X82"
+        , secret: "uV3F3YluFJax1cknvbcGwgjvx4QpvB+leU8dUj2o"
+        , resource: '/'
+        , date: 'Wed, 28 Mar 2007 01:29:59 +0000'
+      });    
+      assert.equal("AWS 0PN5J17HBGZHT7JJ3X82:Db+gepJSUbZKwpx1FR0DLtEYoZA=", str);    
+    },
+    
+    unicodeSign: function(assert) {
+      var str = auth.authorization({
+          verb: 'GET'
+        , key: "0PN5J17HBGZHT7JJ3X82"
+        , secret: "uV3F3YluFJax1cknvbcGwgjvx4QpvB+leU8dUj2o"
+        // NB:- This isn't quite encodeURIComponent('/dictionary/français/préfère')
+        //      nor is it escape('/dictionary/français/préfère')... :(
+        //      And note how Amazon's example string has different case for
+        //      the encoded values of é and ç. Love it.
+        , resource: '/dictionary/fran%C3%A7ais/pr%c3%a9f%c3%a8re'
+        , date: 'Wed, 28 Mar 2007 01:49:49 +0000'
+      });    
+      assert.equal("AWS 0PN5J17HBGZHT7JJ3X82:dxhSBHoI6eVSPcXJqEghlUzZMnY=", str);        
+    }
+    
+}


### PR DESCRIPTION
Amazon's docs provide some test values for signing the authorization header with dummy credentials. I have my own S3 library that uses these values so I went ahead and ported the tests over.

http://docs.amazonwebservices.com/AmazonS3/2006-03-01/dev/index.html?RESTAuthentication.html

One of the tests uses multiple values for the `X-Amz-Meta-ReviewedBy` header, which means the library must support the array form of headers (also supported by node) in order to preserve the ordering on values. I adjusted the `canonicalizeHeaders` function in auth.js to take this into account but I haven't added this support to other files/functions yet.

Amazon's date format in their test signing uses `+0000` instead of `GMT` like javascript does so I needed to allow for string dates in order to get the tests to pass. That doesn't sit quite right, to be honest, but it's just a teensy ternary op so it's probably OK?

If these changes look good I'll follow through with the header-as-array support for other files - let me know what you think.
