### PR TITLE
Making host accessible

### DIFF
--- a/lib/knox/client.js
+++ b/lib/knox/client.js
@@ -31,8 +31,8 @@ var utils = require('./utils')
  */
 
 var Client = module.exports = exports = function Client(options) {
-  this.host = 's3.amazonaws.com';
   utils.merge(this, options);
+  if (!this.host) this.host = 's3.amazonaws.com';
   if (!this.key) throw new Error('aws "key" required');
   if (!this.secret) throw new Error('aws "secret" required');
   if (!this.bucket) throw new Error('aws "bucket" required');


### PR DESCRIPTION
I ran into a problem using know with an amazon S3 bucket which was created on an EU server.
The default host for US buckets is
    s3.amazonaws.com

but for using knox with an EU bucket you need to set the host to
    s3-euwest-1.amazonaws.com

So I made the host accessible via the client options. If it not gets set it defaults to "s3.amazonaws.com"
