### PR TITLE
Added find() method for listing files in bucket - w/ test

### DIFF
--- a/lib/knox/client.js
+++ b/lib/knox/client.js
@@ -51,6 +51,7 @@ var Client = module.exports = exports = function Client(options) {
 
 Client.prototype.request = function(method, filename, headers){
   var options = { host: this.endpoint, port: 80 }
+    , path = join('/', this.bucket, filename)
     , date = new Date
     , headers = headers || {};
 
@@ -66,7 +67,7 @@ Client.prototype.request = function(method, filename, headers){
     , secret: this.secret
     , verb: method
     , date: date
-    , resource: join('/', this.bucket, filename)
+    , resource: url.parse(path).pathname
     , contentType: headers['Content-Type']
     , amazonHeaders: auth.canonicalizeHeaders(headers)
   });
@@ -193,6 +194,40 @@ Client.prototype.putStream = function(stream, filename, headers, fn){
       .on('data', function(chunk){ req.write(chunk); })
       .on('end', function(){ req.end(); });
   });
+};
+
+/**
+ * GET list of files in bucket with optional `headers` and callback `fn`.
+ *
+ * @param {String} filename
+ * @param {Object|Function} headers
+ * @param {Function} fn
+ * @return {Array}
+ * @api public
+ */
+
+Client.prototype.find = function(filename, headers, fn){
+  if ('function' == typeof headers) {
+    fn = headers;
+    headers = {};
+  };
+  this.get(filename, headers).on('response', function(res){
+    res.body = '';
+    res.setEncoding('utf8');
+    res.on('data', function(chunk) {
+      res.body += chunk;
+    });
+    res.on('end', function() {
+      var parseXML = /<Key>(.*?)<\/Key>/g;
+      var files = [];
+      while (true) {
+        var match = parseXML.exec(res.body);
+        if (!match) break;
+        files.push(match[1]);
+      }
+      fn(null, files);
+    });
+  }).end();
 };
 
 /**

--- a/test/knox.test.js
+++ b/test/knox.test.js
@@ -119,6 +119,15 @@ module.exports = {
     });
   },
   
+  'test .find()': function(assert, done){
+    client.find('?prefix=test/', function(err, res){
+      assert.ok(!err);
+      assert.equal('object', typeof res);
+      assert.equal('test/user.json', res[0]);
+      done();
+    });
+  },
+  
   'test .getFile()': function(assert, done){
     client.getFile('/test/user.json', function(err, res){
       assert.ok(!err);


### PR DESCRIPTION
Returns array of filenames in bucket.

Can use any of the request parameters like '?prefix=test/u' to return only files in the test directory starting with 'u'. This feature was a requirement for my project, but I understand if it's something you don't want/need. 
