### PR TITLE
Including query params in requests.

### DIFF
--- a/lib/knox/client.js
+++ b/lib/knox/client.js
@@ -13,13 +13,14 @@ var utils = require('./utils')
   , auth = require('./auth')
   , http = require('http')
   , url = require('url')
+  , qstring = require('querystring')
   , join = require('path').join
   , mime = require('./mime')
   , fs = require('fs');
 
 /**
  * Initialize a `Client` with the given `options`.
- * 
+ *
  * Required:
  *
  *  - `key`     amazon api key
@@ -52,7 +53,39 @@ var Client = module.exports = exports = function Client(options) {
 Client.prototype.request = function(method, filename, headers){
   var options = { host: this.endpoint, port: 80 }
     , date = new Date
-    , headers = headers || {};
+    , headers = headers || {}
+    , parsed = url.parse(filename, true)
+    , query = parsed.query
+    , qKeys
+    , queryToBeSigned = {}
+    , newQuery;
+
+  // http://docs.amazonwebservices.com/AmazonS3/latest/dev/index.html?RESTAuthentication.html
+  // says we only should sign the following query params. Also, the params need to be sorted lexicographically
+  if (query) {
+    qKeys = Object.keys(query).sort();
+    qKeys.forEach(function (k, idx) {
+      if (k === 'acl' ||
+          k === 'location' ||
+          k === 'logging' ||
+          k === 'notification' ||
+          k === 'partNumber' ||
+          k === 'policy' ||
+          k === 'requestPayment' ||
+          k === 'torrent' ||
+          k === 'uploadId' ||
+          k === 'uploads' ||
+          k === 'versionId' ||
+          k === 'versioning' ||
+          k === 'versions' ||
+          k === 'website') {
+        queryToBeSigned[k] = query[k];
+      }
+    });
+    if (Object.keys(queryToBeSigned) > 0) {
+        newQuery = '?' + qstring.stringify(queryToBeSigned);
+    }
+  }
 
   // Default headers
   utils.merge(headers, {
@@ -66,7 +99,11 @@ Client.prototype.request = function(method, filename, headers){
     , secret: this.secret
     , verb: method
     , date: date
-    , resource: join('/', this.bucket, filename)
+    // If filename === '?prefix=test' (Note the missing / at start),
+    // options.path will be equal to '/?prefix=test'
+    // but resource = '' (query param prefix does not need to be signed)
+    // This will cause a 403. Hence adding the 2nd '/'
+    , resource: join('/', this.bucket, parsed.pathname, '/', newQuery)
     , contentType: headers['Content-Type']
     , amazonHeaders: auth.canonicalizeHeaders(headers)
   });
@@ -101,7 +138,7 @@ Client.prototype.request = function(method, filename, headers){
  *          res.on('data', function(chunk){
  *            console.log(chunk.toString());
  *          });
- *        }); 
+ *        });
  *        // Send the request with the file's Buffer obj
  *        req.end(buf);
  *      });
@@ -242,7 +279,7 @@ Client.prototype.head = function(filename, headers){
 };
 
 /**
- * Issue a HEAD request on `filename` with optional `headers` 
+ * Issue a HEAD request on `filename` with optional `headers`
  * and callback `fn` with a possible exception and the response.
  *
  * @param {String} filename
@@ -275,7 +312,7 @@ Client.prototype.del = function(filename, headers){
 };
 
 /**
- * DELETE `filename` with optional `headers` 
+ * DELETE `filename` with optional `headers`
  * and callback `fn` with a possible exception and the response.
  *
  * @param {String} filename
@@ -335,8 +372,8 @@ Client.prototype.signedUrl = function(filename, expiration){
     date: epoch,
     resource: '/' + this.bucket + url.parse(filename).pathname
   });
-  
-  return this.url(filename) + 
+
+  return this.url(filename) +
     '?Expires=' + epoch +
     '&AWSAccessKeyId=' + this.key +
     '&Signature=' + escape(signature);


### PR DESCRIPTION
According to the S3 docs, only certain query parameters should be included while preparing `stringToSign`. Also, the parameters to be included need to lexicographically sorted. See http://docs.amazonwebservices.com/AmazonS3/latest/dev/index.html?RESTAuthentication.html#ConstructingTheCanonicalizedResourceElement

I was trying to `GET /?prefix=test` but the request failed due to the inclusion of the entire query string while preparing the `Authorization` header. After this commit, I am now able to see all keys at the specified prefix.
