### PR TITLE
Fix resource canonicalization bug due to operator precedence

### DIFF
--- a/lib/knox/auth.js
+++ b/lib/knox/auth.js
@@ -184,7 +184,7 @@ exports.canonicalizeResource = function(resource){
     buf.push(key + val);
   });
 
-  return path + buf.length
+  return path + (buf.length
     ? '?' + buf.sort().join('&')
-    : '';
+    : '');
 };


### PR DESCRIPTION
Bug was introduced in LearnBoost/knox@c66971d74284bfdc778a; + operator is of higher precedence than ? : (effectively preventing return of the correct _empty_ resource string)
