### PR TITLE
intermittent "SignatureDoesNotMatch" error on signedUrl fix

### DIFF
--- a/lib/knox/client.js
+++ b/lib/knox/client.js
@@ -339,7 +339,7 @@ Client.prototype.signedUrl = function(filename, expiration){
   return this.url(filename) +
     '?Expires=' + epoch +
     '&AWSAccessKeyId=' + this.key +
-    '&Signature=' + escape(signature);
+    '&Signature=' + encodeURIComponent(signature);
 };
 
 /**


### PR DESCRIPTION
signedUrl signature needs encodeURIComponent() not escape() to prevent SignatureDoesNotMatch errors on signatures containing plus signs.
