### PR TITLE
allow putStream to accept non fs based streams

### DIFF
--- a/lib/knox/client.js
+++ b/lib/knox/client.js
@@ -178,21 +178,34 @@ Client.prototype.putStream = function(stream, filename, headers, fn){
     fn = headers;
     headers = {};
   };
-  fs.stat(stream.path, function(err, stat){
+  var startStream = function(err, stat) {
     if (err) return fn(err);
     // TODO: sys.pump() wtf?
-    var req = self.put(filename, utils.merge({
-        'Content-Length': stat.size
-      , 'Content-Type': mime.lookup(stream.path)
-    }, headers));
-    req.on('response', function(res){
+
+    headers['Content-Length'] = stat.size;
+
+    // skip mime.lookup
+    if (!headers['Content-Type']) {
+      headers['Content-Type'] = mime.lookup(stream.path);
+    }
+
+    var req = self.put(filename, headers);
+    req.on('response', function(res) {
       fn(null, res);
     });
+
     stream
       .on('error', function(err){fn(null, err); })
       .on('data', function(chunk){ req.write(chunk); })
       .on('end', function(){ req.end(); });
-  });
+  };
+  var contentLength = headers['Content-Length'];
+  if (contentLength && contentLength > 0) { // skip fs.stat
+    startStream(null, {size: contentLength});
+  }
+  else {
+    fs.stat(stream.path, startStream);
+  }
 };
 
 /**


### PR DESCRIPTION
when given a content length and content type allow putStream to upload arbitrary streams without using mime.lookup or fs.stat
