### PR TITLE
Add "Content-MD5" header option + authorization signature

### DIFF
--- a/lib/knox/client.js
+++ b/lib/knox/client.js
@@ -15,7 +15,8 @@ var utils = require('./utils')
   , url = require('url')
   , join = require('path').join
   , mime = require('./mime')
-  , fs = require('fs');
+  , fs = require('fs')
+  , crypto = require('crypto');
 
 /**
  * Initialize a `Client` with the given `options`.
@@ -68,6 +69,7 @@ Client.prototype.request = function(method, filename, headers){
     , date: date
     , resource: auth.canonicalizeResource(join('/', this.bucket, filename))
     , contentType: headers['Content-Type']
+    , md5: headers['Content-MD5'] || ''
     , amazonHeaders: auth.canonicalizeHeaders(headers)
   });
 
@@ -155,6 +157,7 @@ Client.prototype.putFile = function(src, filename, headers, fn){
     headers = utils.merge({
         'Content-Length': buf.length
       , 'Content-Type': mime.lookup(src)
+      , 'Content-MD5': crypto.createHash('md5').update(buf).digest('base64')
     }, headers);
     self.put(filename, headers).on('response', function(res){
       fn(null, res);


### PR DESCRIPTION
Add in the "Content-MD5" header option to client.request, ensuring that it used in the authorization signature. Make client.putFile utilize md5 hashing.
