### PR TITLE
Handle request errors

### DIFF
--- a/lib/knox/client.js
+++ b/lib/knox/client.js
@@ -191,6 +191,9 @@ Client.prototype.putStream = function(stream, filename, headers, fn){
     req.on('response', function(res){
       fn(null, res);
     });
+    req.on('error', function(err){
+      fn(err, null);
+    });
     stream
       .on('error', function(err){fn(err); })
       .on('data', function(chunk){ req.write(chunk); })


### PR DESCRIPTION
Right now, request errors (like DNS failures) aren’t handled at all — and if one happens, the process gets killed.
