### PR TITLE
Don't use `path.join` for URLs; it breaks on Windows.

### DIFF
--- a/lib/knox/client.js
+++ b/lib/knox/client.js
@@ -53,7 +53,7 @@ Client.prototype.request = function(method, filename, headers){
   var options = { host: this.endpoint, port: this.port }
     , date = new Date
     , headers = headers || {}
-    , path = url.resolve('/', this.bucket + '/' + filename);
+    , path = url.resolve('/', this.bucket + filename);
 
   // Default headers
   utils.merge(headers, {
@@ -307,7 +307,7 @@ Client.prototype.deleteFile = function(filename, headers, fn){
 
 Client.prototype.url =
 Client.prototype.http = function(filename){
-  return url.resolve('http://' + this.endpoint, this.bucket + '/' + filename);
+  return url.resolve('http://' + this.endpoint, this.bucket + filename);
 };
 
 /**


### PR DESCRIPTION
Using `url.resolve` instead. Fixes GH-56.
