### PR TITLE
Adding a copy method.

### DIFF
--- a/lib/knox/client.js
+++ b/lib/knox/client.js
@@ -124,6 +124,29 @@ Client.prototype.put = function(filename, headers){
 };
 
 /**
+ * Copy files from `sourceFilename` to `destFilename` with optional `headers`.
+ *
+ * Example:
+ *
+ * @param {String} sourceFilename
+ * @param {String} destFilename
+ * @param {Object} headers
+ * @return {ClientRequest}
+ * @api public
+ */
+
+Client.prototype.copy = function(sourceFilename, destFilename, headers){
+  headers = utils.merge({
+      Expect: '100-continue'
+    , 'x-amz-acl': 'public-read'
+  }, headers || {});
+  headers['x-amz-copy-source'] = join('/', this.bucket, sourceFilename);
+  headers['Content-Length'] = 0; // to avoid Node's automatic chunking if omitted
+
+  return this.request('PUT', destFilename, headers);
+};
+
+/**
  * PUT the file at `src` to `filename`, with callback `fn`
  * receiving a possible exception, and the response object.
  *


### PR DESCRIPTION
Manually doing a copy (via PUT) is annoying because you have to remember the bucket name (unlike every other Knox call), and because you have to send Content-Length: 0.
