### PR TITLE
Ensure propagation of errors in http module.

### DIFF
--- a/lib/knox/client.js
+++ b/lib/knox/client.js
@@ -159,11 +159,26 @@ Client.prototype.putFile = function(src, filename, headers, fn){
       , 'Content-Type': mime.lookup(src)
       , 'Content-MD5': crypto.createHash('md5').update(buf).digest('base64')
     }, headers);
-    self.put(filename, headers).on('response', function(res){
-      fn(null, res);
-    }).end(buf);
+    var req = self.put(filename, headers);
+    _registerReqListeners(req, fn);
+    req.end(buf);
   });
 };
+
+/**
+ * Register event listeners on a request object to convert standard http
+ * request events into appropriate call backs.
+ * @param {Request} req The http request
+ * @param {Function} fn(err, res) The callback function.
+ * err - The exception if an exception occurred while sending the http
+ * request (for example if internet connection was lost). 
+ * res - The http response if no exception occurred.
+ * @api private
+ */
+_registerReqListeners = function(req, fn) {
+  req.on('response', function(res){ fn(null, res); });
+  req.on('error', function(err) { fn(err, null); });
+}
 
 /**
  * PUT the given `stream` as `filename` with optional `headers`.
@@ -188,9 +203,8 @@ Client.prototype.putStream = function(stream, filename, headers, fn){
         'Content-Length': stat.size
       , 'Content-Type': mime.lookup(stream.path)
     }, headers));
-    req.on('response', function(res){
-      fn(null, res);
-    });
+    _registerReqListeners(req, fn);
+      
     stream
       .on('error', function(err){fn(err); })
       .on('data', function(chunk){ req.write(chunk); })
@@ -226,9 +240,11 @@ Client.prototype.getFile = function(filename, headers, fn){
     fn = headers;
     headers = {};
   }
-  return this.get(filename, headers).on('response', function(res){
-    fn(null, res);
-  }).end();
+  
+  var req = this.get(filename, headers);
+  _registerReqListeners(req, fn);
+  req.end();
+  return req;
 };
 
 /**
@@ -259,9 +275,10 @@ Client.prototype.headFile = function(filename, headers, fn){
     fn = headers;
     headers = {};
   }
-  return this.head(filename, headers).on('response', function(res){
-    fn(null, res);
-  }).end();
+  var req = this.head(filename, headers);
+  _registerReqListeners(req, fn);
+  req.end();
+  return req;
 };
 
 /**
@@ -292,9 +309,9 @@ Client.prototype.deleteFile = function(filename, headers, fn){
     fn = headers;
     headers = {};
   }
-  return this.del(filename, headers).on('response', function(res){
-    fn(null, res);
-  }).end();
+  var req = this.del(filename, headers)
+  _registerReqListeners(req, fn);
+  req.end();
 };
 
 /**


### PR DESCRIPTION
Hi, here're the details of my change:

When an error occurs in the core http module, an error event is emitted by a request object. For knox client's putFile, putStream, readFile, etc. the caller does not get a reference to the request object and does not get a chance to catch errors occuring in http module except through a global error handler. This change ensures errors occuring in the underlying http module are propagated through the callback function.

The easiest way to repro an error occuring in the http module is to try and send a request without an active internet connection. I believe the default behavior is a crash.

Thanks,
Shu
