### PR TITLE
Update example in README to use correct content-type

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -92,7 +92,7 @@ An example of moving a file:
 
 ```js
 client.put('0/0/0.png', {
-    'Content-Type': 'image/jpg'
+    'Content-Type': 'image/jpeg'
   , 'Content-Length': '0'
   , 'x-amz-copy-source': '/test-tiles/0/0/0.png'
   , 'x-amz-metadata-directive': 'REPLACE'


### PR DESCRIPTION
Silly little change, but it tripped us up. Files with 'Content-Type':
'image/jpg' were giving us browser warnings, since it should technically
be 'Content-Type': 'image/jpeg'.
http://en.wikipedia.org/wiki/MIME_type#Type_image
