### PR TITLE
Make `putStream` put any stream (finally). Closes #72.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -78,13 +78,16 @@ client.putFile('my.json', '/user.json', function(err, res){
 Another alternative is to stream via `Client#putStream()`, for example:
 
 ```js
-var stream = fs.createReadStream('data.json');
-client.putStream(stream, '/some-data.json', function(err, res){
-  // Logic
+http.get('http://google.com/doodle.png', function(res){
+  var headers = {
+      'Content-Length': res.headers['content-length']
+    , 'Content-Type': res.headers['content-type']
+  };
+  client.putStream(res, '/doodle.png', headers, function (err, res) {
+    // Logic
+  });
 });
 ```
-
-(Note that this only works with file streams currently.)
 
 An example of moving a file:
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -175,9 +175,6 @@ Client.prototype.copy = function(sourceFilename, destFilename, headers){
  * PUT the file at `src` to `filename`, with callback `fn`
  * receiving a possible exception, and the response object.
  *
- * NOTE: this method reads the _entire_ file into memory using
- * fs.readFile(), and is not recommended or large files.
- *
  * Example:
  *
  *    client
@@ -200,49 +197,39 @@ Client.prototype.putFile = function(src, filename, headers, fn){
     fn = headers;
     headers = {};
   };
-  fs.readFile(src, function(err, buf){
+
+  fs.stat(src, function (err, stat) {
     if (err) return fn(err);
+
     headers = utils.merge({
-        'Content-Length': buf.length
+        'Content-Length': stat.size
       , 'Content-Type': mime.lookup(src)
-      , 'Content-MD5': crypto.createHash('md5').update(buf).digest('base64')
     }, headers);
-    var req = self.put(filename, headers);
-    registerReqListeners(req, fn);
-    req.end(buf);
+
+    var fileStream = fs.createReadStream(src);
+    self.putStream(fileStream, filename, headers, fn);
   });
 };
 
 /**
- * PUT the given `stream` as `filename` with optional `headers`.
+ * PUT the given `stream` as `filename` with `headers`.
+ * `headers` must contain `'Content-Length'` at least.
  *
  * @param {Stream} stream
  * @param {String} filename
- * @param {Object|Function} headers
+ * @param {Object} headers
  * @param {Function} fn
  * @api public
  */
 
 Client.prototype.putStream = function(stream, filename, headers, fn){
   var self = this;
-  if ('function' == typeof headers) {
-    fn = headers;
-    headers = {};
-  };
-  fs.stat(stream.path, function(err, stat){
-    if (err) return fn(err);
-    // TODO: sys.pump() wtf?
-    var req = self.put(filename, utils.merge({
-        'Content-Length': stat.size
-      , 'Content-Type': mime.lookup(stream.path)
-    }, headers));
-    registerReqListeners(req, fn);
+  var req = self.put(filename, headers);
 
-    stream
-      .on('error', function(err){ fn(err); })
-      .on('data', function(chunk){ req.write(chunk); })
-      .on('end', function(){ req.end(); });
-  });
+  registerReqListeners(req, fn);
+  stream.on('error', fn)
+
+  stream.pipe(req);
 };
 
 /**

--- a/test/knox.test.js
+++ b/test/knox.test.js
@@ -5,6 +5,7 @@
 
 var knox = require('..')
   , fs = require('fs')
+  , http = require('http')
   , assert = require('assert')
   , crypto = require('crypto');
 
@@ -106,12 +107,35 @@ module.exports = {
     });
   },
 
-  'test .putStream()': function(done){
-    var stream = fs.createReadStream(jsonFixture);
-    client.putStream(stream, '/test/user.json', function(err, res){
-      assert.ok(!err);
-      if (100 !== res.statusCode) assert.equal(200, res.statusCode);
-      done();
+  'test .putStream() with file stream': function(done){
+    fs.stat(jsonFixture, function(err, stat){
+      if (err) throw err;
+      var headers = {
+          'Content-Length': stat.size
+        , 'Content-Type': 'application/json'
+        , 'x-amz-acl': 'private'
+      };
+      var stream = fs.createReadStream(jsonFixture);
+      client.putStream(stream, '/test/user.json', headers, function(err, res){
+        assert.ok(!err);
+        if (100 !== res.statusCode) assert.equal(200, res.statusCode);
+        done();
+      });
+    })
+  },
+
+  'test .putStream() with http stream': function(done){
+    http.get('http://google.com', function(res){
+      var headers = {
+          'Content-Length': res.headers['content-length']
+        , 'Content-Type': res.headers['content-type']
+        , 'x-amz-acl': 'private'
+      };
+      client.putStream(res, '/google', headers, function (err, res) {
+        assert.ok(!err);
+        if (100 !== res.statusCode) assert.equal(200, res.statusCode);
+        done();
+      });
     });
   },
 


### PR DESCRIPTION
Also reimplement `putFile` in terms of it, so that it streams files from disk. This loses the MD5 sadly, but it's a small price to pay.

Updated README with an example of a HTTP stream instead of another file stream, and added a test to make sure that example actually works.

Related: #14, #32, #48, #57.

@visionmedia, @guille, and anyone else: code review before I merge?? Want to make sure this is done right.
