### PR TITLE
Add charset to content type header.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -190,9 +190,17 @@ Client.prototype.putFile = function(src, filename, headers, fn){
   fs.stat(src, function (err, stat) {
     if (err) return fn(err);
 
+    var contentType = mime.lookup(src);
+
+    // Add charset if it's known.
+    var charset = mime.charsets.lookup(contentType);
+    if (charset) {
+      contentType += '; charset=' + charset;
+    }
+
     headers = utils.merge({
         'Content-Length': stat.size
-      , 'Content-Type': mime.lookup(src)
+      , 'Content-Type': contentType
     }, headers);
 
     var stream = fs.createReadStream(src);


### PR DESCRIPTION
Useful for text/\* types that contain unicode characters.
