### PR TITLE
Make the port configurable.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -87,6 +87,10 @@ Client.prototype.request = function(method, filename, headers){
     , date = new Date
     , headers = headers || {};
 
+  if ('undefined' != typeof this.port) {
+    options.port = this.port;
+  }
+
   filename = ensureLeadingSlash(filename);
 
   // Default headers


### PR DESCRIPTION
I swear I remember this being available at some point. I would like to write tests for my project that depends on `knox` using fakes3. To do this I need the `knox` port to be configurable. Pretty please?
