### PR TITLE
S3: Remove default canned ACL when access grants are used 

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -157,6 +157,16 @@ Client.prototype.put = function(filename, headers){
       Expect: '100-continue'
     , 'x-amz-acl': 'public-read'
   }, headers || {});
+  
+  // S3 does not allow canned ACLs if specific access grants are used.
+  if (headers['x-amz-grant-read']      || 
+      headers['x-amz-grant-write']     ||
+      headers['x-amz-grant-read-acp']  ||
+      headers['x-amz-grant-write-acp'] ||
+      headers['x-amz-grant-full-control']) {
+        delete headers['x-amz-acl'];
+  }
+  
   return this.request('PUT', filename, headers);
 };
 
@@ -293,6 +303,15 @@ Client.prototype.copy = function(sourceFilename, destFilename, headers){
   }, headers || {});
   headers['x-amz-copy-source'] = '/' + this.bucket + sourceFilename;
   headers['Content-Length'] = 0; // to avoid Node's automatic chunking if omitted
+
+  // S3 does not allow canned ACLs if specific access grants are used.
+  if (headers['x-amz-grant-read']      || 
+      headers['x-amz-grant-write']     ||
+      headers['x-amz-grant-read-acp']  ||
+      headers['x-amz-grant-write-acp'] ||
+      headers['x-amz-grant-full-control']) {
+        delete headers['x-amz-acl'];
+  }
 
   return this.put(destFilename, headers);
 };


### PR DESCRIPTION
Knox by default adds the canned 'public-read' ACL to PUT and COPY requests. However, if an app manually specifies an access grant such as 'x-amz-grant-read', both the canned ACL and access grants will be present in the headers, and the request will fail with the following error:

'Specifying both Canned ACLs and Header Grants is not allowed'

This behavior is documented on the respective API pages, these are to be used exclusive of each other.

This change simply removes the default x-amz-acl header when any of the access grant headers are specified by the app. Let me know if there is a better way/place to handle this logic, thanks.
