### PR TITLE
Don't specify x-amz-acl by default.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -155,7 +155,6 @@ Client.prototype.request = function(method, filename, headers){
 Client.prototype.put = function(filename, headers){
   headers = utils.merge({
       Expect: '100-continue'
-    , 'x-amz-acl': 'public-read'
   }, headers || {});
   return this.request('PUT', filename, headers);
 };
@@ -289,7 +288,6 @@ Client.prototype.copy = function(sourceFilename, destFilename, headers){
   sourceFilename = ensureLeadingSlash(sourceFilename);
   headers = utils.merge({
       Expect: '100-continue'
-    , 'x-amz-acl': 'public-read'
   }, headers || {});
   headers['x-amz-copy-source'] = '/' + this.bucket + sourceFilename;
   headers['Content-Length'] = 0; // to avoid Node's automatic chunking if omitted


### PR DESCRIPTION
x-amz-acl is not a required header, and it's supposed to default to 'private'.
The current behavior is unnecessary and violates the principle of least surprise,
which is particularly problematic in this case because the expected behavior is that
files uploaded with no specified ACL are private, and instead they are world-readable
