### PR TITLE
Add support for temporary security tokens

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -19,6 +19,7 @@ API. First things first, create an S3 client:
 var client = knox.createClient({
     key: '<api-key-here>'
   , secret: '<secret-here>'
+  , token: '<optional-temporary-security-token-here>'
   , bucket: 'learnboost'
 });
 ```

--- a/lib/client.js
+++ b/lib/client.js
@@ -100,6 +100,9 @@ Client.prototype.request = function(method, filename, headers){
     , Host: this.endpoint
   });
 
+  if ('token' in this)
+    headers['x-amz-security-token'] = this.token;
+
   // Authorization header
   headers.Authorization = auth.authorization({
       key: this.key


### PR DESCRIPTION
As an example of why this is necessary, an EC2 instance may be associated with an IAM role. The instance would then retrieve temporary security credentials from the instance metadata service. These credentials include a temporary security token that must be included in request headers.
