### PR TITLE
Make the http agent configurable

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -84,7 +84,7 @@ var Client = module.exports = exports = function Client(options) {
  */
 
 Client.prototype.request = function(method, filename, headers){
-  var options = { host: this.endpoint }
+  var options = { host: this.endpoint, agent: this.agent }
     , date = new Date
     , headers = headers || {};
 


### PR DESCRIPTION
This makes the agent option on http(s).request configurable.  This makes it possible to define your own agent if you need to do more than customize the global agent.  One example use is to be able to pass in an [agentkeepalive](https://github.com/TBEDP/agentkeepalive) agent which helps get around TCP memory loading issues if doing a lot of requests.
