### PR TITLE
Fix .signedUrl to work without a leading slash

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -665,7 +665,7 @@ Client.prototype.signedUrl = function(filename, expiration){
     , resource: resource
   });
 
-  return this.url(filename) +
+  return this.url(ensureLeadingSlash(filename)) +
     '?Expires=' + epoch +
     '&AWSAccessKeyId=' + this.key +
     '&Signature=' + encodeURIComponent(signature);

--- a/test/knox.test.js
+++ b/test/knox.test.js
@@ -505,5 +505,23 @@ module.exports = {
                  '&AWSAccessKeyId=' +
                  client.key +
                  '&Signature=' + encodeURIComponent(signature), signedUrl);
+  },
+
+  'test .signedUrl() without a leading slash': function(){
+    var date = new Date(2020, 1, 1);
+    var timestamp = date.getTime() * 0.001;
+    var signedUrl = client.signedUrl('test/user.json', date); // no leading slash
+    var signature = signQuery({
+        secret: client.secret
+      , date: timestamp
+      , resource: '/' + client.bucket + '/test/user.json'
+    });
+
+    assert.equal('https://' + client.bucket +
+                 '.s3.amazonaws.com/test/user.json?Expires=' +
+                 timestamp +
+                 '&AWSAccessKeyId=' +
+                 client.key +
+                 '&Signature=' + encodeURIComponent(signature), signedUrl);
   }
 };


### PR DESCRIPTION
Other commands work with relative filenames but `client.signedUrl` did not.  This patch makes sure that it does and adds a test to verify it.
