### PR TITLE
Add proxy support

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -118,12 +118,6 @@ Client.prototype.request = function(method, filename, headers){
 
   filename = ensureLeadingSlash(filename);
 
-  // Proxy passthrough requires a fully qualified domain for the path
-  if (this.proxy) {
-    var protocol = this.secure ? 'https://' : 'http://';
-    filename = protocol + this.endpoint + filename;
-  }
-
   // Default headers
   utils.merge(headers, {
       Date: date.toUTCString()
@@ -147,8 +141,15 @@ Client.prototype.request = function(method, filename, headers){
 
   // Issue request
   options.method = method;
-  options.path = filename;
   options.headers = headers;
+
+  if (this.proxy) {
+    var protocol = this.secure ? 'https://' : 'http://';
+    options.path = protocol + this.endpoint + filename;
+  } else {
+    options.path = filename;
+  }
+
   var req = (this.secure ? https : http).request(options);
   req.url = this.url(filename);
 


### PR DESCRIPTION
Add optional proxy flag/port when creating the knox client.

It will properly modify the host option/headers for the http request, as well as the path.
