### PR TITLE
Options for non-AWS Hosters

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -117,6 +117,10 @@ var Client = module.exports = exports = function Client(options) {
       domain = 's3-' + options.region + '.amazonaws.com';
     }
   }
+  // Allow other domains to be specified, e.g. for hosters like Hosteurope
+  if (options.domain){
+    domain = options.domain;
+  }
   this.endpoint = options.bucket + '.' + domain;
   this.secure = 'undefined' == typeof options.port;
   utils.merge(this, options);


### PR DESCRIPTION
As my hoster (hosteurope) provides AWS S3 compatible cloud storage (seems like Riak CS), I added options.domain for custom domain names.
