### PR TITLE
check type of token property instead of using in operator

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -152,7 +152,7 @@ Client.prototype.request = function(method, filename, headers){
     , Host: this.endpoint
   });
 
-  if ('token' in this)
+  if ('undefined' != typeof this.token)
     headers['x-amz-security-token'] = this.token;
 
   // Authorization header

--- a/test/knox.test.js
+++ b/test/knox.test.js
@@ -356,6 +356,32 @@ module.exports = {
     }).end();
   },
 
+  'test undefined token is not set in header': function(done){
+    var client = knox.createClient({
+        key: 'foobar'
+      , secret: 'baz'
+      , bucket: 'misc'
+      , token: undefined
+    });
+    var req = client.get('/');
+    assert.equal(false, req._headers.hasOwnProperty('x-amz-security-token'));
+    req.end();
+    done();
+  },
+
+  'test token is set in header': function(done){
+    var client = knox.createClient({
+        key: 'foobar'
+      , secret: 'baz'
+      , bucket: 'misc'
+      , token: 'foo'
+    });
+    var req = client.get('/');
+    assert.equal('foo', req._headers['x-amz-security-token']);
+    req.end();
+    done();
+  },
+
   'test header lowercasing': function(){
     var headers = { 'X-Amz-Acl': 'private' };
     var req = client.put('/test/user.json', headers);


### PR DESCRIPTION
This makes it more convenient to define knox clients like:

``` javascript
var client = knox.createClient({
    key: '<api-key-here>'
  , secret: '<secret-here>'
  , bucket: 'learnboost'
  , token: tokenVariableMightBeUndefined // w/ this patch, headers['x-amz-security-token'] will not get set if this variable here is undefined.
});
```
