### PR TITLE
Add STS support for signed URLs.

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -135,6 +135,8 @@ exports.stringToSign = function(options){
 exports.queryStringToSign = function(options){
   return (options.verb || 'GET') + '\n\n\n' +
     options.date + '\n' +
+    (typeof options.token !== 'undefined' ?
+      'x-amz-security-token:' + options.token + '\n' : '') +
     options.resource;
 };
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -736,6 +736,7 @@ Client.prototype.signedUrl = function(filename, expiration, otherParams, verb){
     , date: epoch
     , resource: resource
     , verb: verb || 'GET'
+    , token: this.token
   });
 
   var queryString = qs.stringify(utils.merge({
@@ -743,6 +744,9 @@ Client.prototype.signedUrl = function(filename, expiration, otherParams, verb){
     AWSAccessKeyId: this.key,
     Signature: signature
   }, otherParams || {}));
+
+  if (typeof this.token !== 'undefined')
+      queryString += '&x-amz-security-token=' + encodeURIComponent(this.token);
 
   return this.url(ensureLeadingSlash(filename)) + '?' + queryString;
 };

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -88,6 +88,21 @@ module.exports = {
       , resource
     ].join('\n');
     assert.equal(expectedGet, strGet);
+
+    var strGetToken = auth.queryStringToSign({
+        verb: 'GET'
+      , date: date
+      , resource: resource
+      , token: 'foobar'
+    });
+
+    var expectedGetToken = [
+        'GET\n\n'
+      , date
+      , 'x-amz-security-token:foobar'
+      , resource
+    ].join('\n');
+    assert.equal(expectedGetToken, strGetToken);
   },
 
   'test .canonicalizeResource()': function(){

--- a/test/knox.test.js
+++ b/test/knox.test.js
@@ -625,6 +625,33 @@ module.exports = {
                  , signedUrl);
   },
 
+  'test .signedUrl() with sts token': function(){
+    var date = new Date(2020, 1, 1);
+    var timestamp = date.getTime() * 0.001;
+    var tokenClient = knox.createClient({
+      bucket: 'example',
+      key: 'foo',
+      secret: 'bar',
+      token: 'baz'
+    });
+    var signedUrl = tokenClient.signedUrl('/test/user.json', date);
+    var signature = signQuery({
+        secret: tokenClient.secret
+      , date: timestamp
+      , resource: '/' + tokenClient.bucket + '/test/user.json'
+      , token: 'baz'
+    });
+
+    assert.equal('https://' + tokenClient.bucket +
+                 '.s3.amazonaws.com/test/user.json?Expires=' +
+                 timestamp +
+                 '&AWSAccessKeyId=' +
+                 tokenClient.key +
+                 '&Signature=' + encodeURIComponent(signature) +
+                 '&x-amz-security-token=baz', signedUrl);
+
+  },
+
   'test .signedUrl() with verb HEAD': function(){
     var date = new Date(2020, 1, 1);
     var timestamp = date.getTime() * 0.001;


### PR DESCRIPTION
This pull adds support for using STS temporary key/secret/token combos to generate signed URLs.

http://docs.aws.amazon.com/STS/latest/APIReference/Welcome.html
