### PR TITLE
Fixed overwriting bucket name with undefined.

### DIFF
--- a/test/initClients.js
+++ b/test/initClients.js
@@ -12,7 +12,7 @@ module.exports = function(){
     client = knox.createClient(auth);
 
     var auth2 = utils.merge({}, auth);
-    auth2.bucket = auth2.bucket2;
+    auth2.bucket = auth.bucket;
     client2 = knox.createClient(auth2);
 
     var authUsWest2 = utils.merge({}, auth);


### PR DESCRIPTION
Running `npm test` fails with `[Error: aws "bucket" required]` because the bucket name was being overwritten with an undefined value.
