### PR TITLE
fix putStream for streams2

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -20,7 +20,6 @@ var Emitter = require('events').EventEmitter
   , crypto = require('crypto')
   , xml2js = require('xml2js')
   , util = require('util')
-  , stream = require('readable-stream')
   , StreamCounter = require('stream-counter')
   , qs = require('querystring');
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "mime": "*",
     "xml2js": "0.2.x",
     "debug": "~0.7.0",
-    "readable-stream": "~1.0.2",
     "stream-counter": "~0.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
before this change, I have to do an additional pipe on the stream as a workaround:

https://github.com/superjoe30/node-multiparty/blob/master/examples/s3.js#L65

after this change everything works as expected with node v0.10 with putStream.

as a side note, multiparty has an example of streaming file uploads straight to s3 with knox without ever touching your hard drive. Hurray!
