### PR TITLE
Add port to endpoint if passed custom port

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -141,7 +141,8 @@ var Client = module.exports = exports = function Client(options) {
       domain = 's3-' + options.region + '.amazonaws.com';
     }
   }
-  this.endpoint = options.bucket + '.' + domain;
+  var port = 'undefined' == typeof options.port ? "" : ":" + options.port
+  this.endpoint = options.bucket + '.' + domain + port;
   this.secure = 'undefined' == typeof options.port;
 
   // HTTP in Node.js < 0.12 is horribly broken, and leads to lots of "socket
@@ -166,13 +167,9 @@ var Client = module.exports = exports = function Client(options) {
  */
 
 Client.prototype.request = function(method, filename, headers){
-  var options = { host: this.endpoint, agent: this.agent }
+  var options = { hostname: this.endpoint, agent: this.agent }
     , date = new Date
     , headers = headers || {};
-
-  if ('undefined' != typeof this.port) {
-    options.port = this.port;
-  }
 
   filename = encodeSpecialCharacters(ensureLeadingSlash(filename));
 

--- a/test/knox.test.js
+++ b/test/knox.test.js
@@ -13,6 +13,21 @@ var clientUsWest2 = clients.clientUsWest2;
 var jsonFixture = __dirname + '/fixtures/user.json';
 
 module.exports = {
+  'test endpoint with custom port': function(done){
+    var customPortClient = knox.createClient({
+        key: 'foobar'
+      , secret: 'baz'
+      , bucket: 'misc'
+      , port: 81
+    });
+
+    assert.equal(
+        'http://misc.s3.amazonaws.com:81/test/user.json'
+      , customPortClient.url('/test/user.json'));
+
+    done();
+  },
+
   'test .putFile()': function(done){
     var n = 0;
     client.putFile(jsonFixture, '/test/user2.json', function(err, res){


### PR DESCRIPTION
Closes issue #168.

Passes all tests except for:

```
  ✖ 2 of 58 tests failed:

  1)  test .request() to get ACL (?acl):
     Error: socket hang up
      at createHangUpError (http.js:1409:15)
      at CleartextStream.socketCloseListener (http.js:1459:23)
      at CleartextStream.EventEmitter.emit (events.js:95:17)
      at tls.js:616:10
      at process._tickCallback (node.js:415:13)

  2)  test .deleteMultiple():
     Error: socket hang up
      at createHangUpError (http.js:1409:15)
      at CleartextStream.socketCloseListener (http.js:1459:23)
      at CleartextStream.EventEmitter.emit (events.js:95:17)
      at tls.js:616:10
      at process._tickCallback (node.js:415:13)
```

Those fail on master for me as well, so I'm not sure what's up with them.
