### PR TITLE
ensure cleanup runs before callback invoked, to prevent one cause of double callbacks

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -54,16 +54,16 @@ function registerReqListeners(req, fn){
 
   function onResponse(res){
     if (!hasCalledBack) {
+      cleanup();
       fn(null, res);
     }
-    cleanup();
   }
 
   function onError(err){
     if (!hasCalledBack) {
+      cleanup();
       fn(err);
     }
-    cleanup();
   }
 
   req.on('response', onResponse);


### PR DESCRIPTION
ensure that cleanup runs before the callback is invoked, to prevent for example a thrown exception in the callback preventing the cleanup from happening.
