### PR TITLE
Add s3-lister to Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -400,6 +400,12 @@ connectivity to S3 without bringing it to a ginding halt.
 [@goodeggs]: https://github.com/goodeggs
 [knox-copy]: https://npmjs.org/package/knox-copy
 
+
+[@segmentio][] created [s3-lister][] to stream a list of bucket keys using the new streams2 interface.
+
+[@segmentio]: https://github.com/segmentio
+[s3-lister]: https://npmjs.org/package/s3-lister
+
 ## Running Tests
 
 To run the test suite you must first have an S3 account. Then create a file named


### PR DESCRIPTION
We built a library to stream all the keys of a large s3 bucket (before I knew about knox-copy). I wanted to add it the readme if you're looking for a non-coffeescript or stream.Readable library.

Let me know if there's anything else I should change!
