### PR TITLE
Use port in request if specified.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -240,6 +240,7 @@ var Client = module.exports = exports = function Client(options) {
 
   var portSuffix = 'undefined' == typeof options.port ? "" : ":" + options.port;
   this.secure = 'undefined' == typeof options.port;
+  this.port = options.port;
 
   if (options.style === 'virtualHosted') {
     this.host = options.bucket + '.' + options.endpoint;
@@ -275,6 +276,10 @@ Client.prototype.request = function(method, filename, headers){
     , date = new Date
     , headers = headers || {}
     , fixedFilename = encodeSpecialCharacters(ensureLeadingSlash(filename));
+
+  if('undefined' != this.port) {
+    options.port = this.port;
+  }
 
   // Default headers
   headers.Date = date.toUTCString()


### PR DESCRIPTION
When using knox with an S3 emulator such as fakes3[1], the port is
typically different from the default http/https ports (80/433).

This patch passes options.port to the http(s) options. Without this
patch, the request will be issued to the default port (80/433) and
result in an ECONNREFUSED error.

[1] https://github.com/jubos/fake-s3
