### PR TITLE
#188 copyTo accepts object as a destination bucket

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -513,6 +513,7 @@ Client.prototype.copyFile = function(sourceFilename, destFilename, headers, fn){
  * with optional `headers`.
  *
  * @param {String} sourceFilename
+ * @param {String|Object} destBucket
  * @param {String} destFilename
  * @param {Object} headers
  * @return {ClientRequest}
@@ -521,7 +522,11 @@ Client.prototype.copyFile = function(sourceFilename, destFilename, headers, fn){
 
 Client.prototype.copyTo = function(sourceFilename, destBucket, destFilename, headers){
   var options = utils.merge({}, this.options);
-  options.bucket = destBucket;
+  if (typeof destBucket == 'string') {
+    options.bucket = destBucket;
+  } else {
+    utils.merge(options, destBucket);
+  }
   var client = exports.createClient(options);
   return client.put(destFilename, getCopyHeaders(this.bucket, sourceFilename, headers));
 };
@@ -793,7 +798,7 @@ Client.prototype.list = function(params, headers, fn){
 
   var url = params ? '?' + qs.stringify(params) : '';
 
-  this.getFile(url, headers, function(err, res){
+  return this.getFile(url, headers, function(err, res){
     if (err) return fn(err);
 
     var xmlStr = '';


### PR DESCRIPTION
Since I still don't know how to fix the regression about the need to pass region, here is an enhancement that allows to copy files between buckets in different regions by passing region and bucket as an object.

Also there is a quick fix for #list api consistency, all other functions do return request object.
