### PR TITLE
Add CommonPrefixes as an Array for normalizing data

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -747,7 +747,8 @@ var RESPONSE_NORMALIZATION = {
     IsTruncated: Boolean,
     LastModified: Date,
     Size: Number,
-    Contents: Array
+    Contents: Array,
+    CommonPrefixes: Array
 };
 
 /**


### PR DESCRIPTION
CommonPrefixes is not being transformed to an array like Contents is when there is only one element in the array - simple change.
