### PR TITLE
Fixes double encoding issue presented with the 0.8.7 release

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -815,7 +815,9 @@ Client.prototype.list = function(params, headers, fn){
     params = null;
   }
 
-  var url = params ? '?' + qs.stringify(params) : '';
+  // Stringify the list params but don't encode them yet, since ::request
+  // already encodes the value, leading to double-encoding issues
+  var url = params ? '?' + decodeURIComponent(qs.stringify(params)) : '';
 
   return this.getFile(url, headers, function(err, res){
     if (err) return fn(err);

--- a/test/knox.test.js
+++ b/test/knox.test.js
@@ -475,6 +475,34 @@ function runTestsForStyle(style, userFriendlyName) {
           });
         });
       });
+
+      it('should list files with a specified prefix with slash', function (done) {
+        var files = ['/list/slash-1.json', '/list/slash-2.json'];
+
+        client.putFile(jsonFixture, files[0], function (err, res) {
+          assert.ifError(err);
+          client.putFile(jsonFixture, files[1], function (err, res) {
+            assert.ifError(err);
+            client.list({ prefix: 'list/slash-' }, function (err, data) {
+              assert.ifError(err);
+
+              assert.strictEqual(data.Prefix, 'list/slash-');
+              assert.strictEqual(data.IsTruncated, false);
+              assert.strictEqual(data.MaxKeys, 1000);
+              assert.strictEqual(data.Contents.length, 2);
+              assert(data.Contents[0].LastModified instanceof Date);
+              assert.strictEqual(typeof data.Contents[0].Size, 'number');
+              assert.deepEqual(
+                Object.keys(data.Contents[0]),
+                ['Key', 'LastModified', 'ETag', 'Size', 'Owner', 'StorageClass']
+              );
+
+              done();
+            });
+          });
+        });
+      });
+
     });
 
     describe('request()', function () {
@@ -498,6 +526,8 @@ function runTestsForStyle(style, userFriendlyName) {
                   '<Object><Key>test/direct-pipe.json</Key></Object>' +
                   '<Object><Key>list/user1.json</Key></Object>' +
                   '<Object><Key>list/user2.json</Key></Object>' +
+                  '<Object><Key>list/slash-1.json</Key></Object>' +
+                  '<Object><Key>list/slash-2.json</Key></Object>' +
                   '</Delete>';
 
         var req = client.request('POST', '/?delete', {


### PR DESCRIPTION
The 0.8.7 release causes a new issue when using the `list` function with params.prefix, when prefix has special characters in it (like slashes).  This causes lists to fail in those cases because the prefix is mangled.

```
prefix: 'foo/bar-wildcard',
delimiter: '/'
```

This changed the GET that looked like this in <= 0.8.6:
`/?prefix=foo%2Fbar-wildcard&delimiter=%2F`

To the GET that looked like this in 0.8.7:
`/?prefix=foo%252Fbar-wildcard&delimiter=%252F`

The fix is to pass through the qs.stringify result as an unencoded query string, so that when `request` picks it up, it encodes it properly, as opposed to double-encoding.
