### PR TITLE
Fix listing files support, when using vblob as backend

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -278,7 +278,7 @@ Client.prototype.request = function(method, filename, headers){
   var options = { hostname: this.host, agent: this.agent, port: this.port }
     , date = new Date
     , headers = headers || {}
-    , fixedFilename = encodeSpecialCharacters(ensureLeadingSlash(filename));
+    , fixedFilename = (filename && filename.length > 0) ? encodeSpecialCharacters(ensureLeadingSlash(filename)) : "";
 
   // Default headers
   headers.Date = date.toUTCString()


### PR DESCRIPTION
Fixes a problem when using knox with vblob backend ( https://github.com/cloudfoundry/vblob ).

If vblob is configured to use s3-authentication scheme and user tries to call Client.list()-function of knox, the requests will fail. This is caused by differences in 'resource'-parameter used in Authorization-module. When knox is forming the 'resource' parameter, it uses 'fixedFilename'-variable as one part. If 'filename' is empty 'fixedFilename' will get the value: '/'. This slash is extraneous for 'resource'-parameter, when requesting a list of files and causes vblob to reject the request.

I don't have possibility to test this against _real_ S3 (no credentials), so please ensure that this doesn't break anything by running the tests.
