### PR TITLE
Fixed special characters in filename for putFile()

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -97,6 +97,15 @@ function getHeader(headers, headerNameLowerCase) {
   return null;
 }
 
+function getHeaderName(headers, headerNameLowerCase) {
+  for (var header in headers) {
+    if (header.toLowerCase() === headerNameLowerCase) {
+      return header;
+    }
+  }
+  return null;
+}
+
 function isNotDnsCompliant(bucket) {
   if (bucket.length > MAX_NON_US_STANDARD_BUCKET_LENGTH) {
     return 'is more than ' + MAX_NON_US_STANDARD_BUCKET_LENGTH + ' characters';
@@ -397,6 +406,11 @@ Client.prototype.putFile = function(src, filename, headers, fn){
         'Content-Length': stat.size
       , 'Content-Type': contentType
     }, headers);
+
+    if( getHeader(headers, 'x-amz-meta-filename') ) {
+      var fileHeader = getHeaderName(headers, 'x-amz-meta-filename');
+      headers[fileHeader] = encodeSpecialCharacters(getHeader(headers, 'x-amz-meta-filename'));
+    }
 
     var stream = fs.createReadStream(src);
 
@@ -833,7 +847,7 @@ Client.prototype.list = function(params, headers, fn){
         .parseString(xmlStr, function(err, data){
           if (err) return fn(err);
           if (data == null) return fn(new Error('null response received'));
-          
+
           delete data.$;
           normalizeResponse(data);
 

--- a/test/knox.test.js
+++ b/test/knox.test.js
@@ -250,6 +250,35 @@ function runTestsForStyle(style, userFriendlyName) {
           assert(event.written);
         });
       });
+
+      it('should handle filenames with an apostrophe in filename header', function (done) {
+        var header = { 'x-amz-meta-filename': 'hello I have a \' in my name' };
+
+        clientUsWest2.putFile(jsonFixture, '/test/user2.json', header, function (err, res) {
+          assert.ifError(err);
+          assert.equal(res.statusCode, 200);
+
+          clientUsWest2.get('/test/user2.json').on('response', function (res) {
+            assert.equal(res.headers['content-type'], 'application/json');
+            done();
+          }).end();
+        });
+      });
+
+      it('should handle filenames with strange unicode values in filename header', function (done) {
+        var header = { 'x-amz-meta-filename': 'ø' };
+
+        clientUsWest2.putFile(jsonFixture, '/test/user2.json', header, function (err, res) {
+          assert.ifError(err);
+          assert.equal(res.statusCode, 200);
+
+          clientUsWest2.get('/test/user2.json').on('response', function (res) {
+            assert.equal(res.headers['content-type'], 'application/json');
+            done();
+          }).end();
+        });
+      });
+
     });
 
     describe('putBuffer()', function () {


### PR DESCRIPTION
If headers are included, name header is not passed through any
escape operations, so files with unicode characters will throw
mystery errors in your application.  I've included relavent
tests that fail if the filename header is included.

I've added a helper function to the client to retrieve the key
used for the `x-amz-meta-filename` header (as it can be cased
different ways).  I then use that to set an escaped filename in
the merged headers, if passed.

Sorry about the slight formatting change, my text editor auto-trims
on save.
