### PR TITLE
Use s3.amazonaws.com endpoint when region specified is us-east-1

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -222,13 +222,11 @@ var Client = module.exports = exports = function Client(options) {
   autoDetermineStyle(options);
 
   if (!options.endpoint) {
-    if (!options.region) {
+    if (!options.region || options.region === 'us-standard' || options.region === 'us-east-1') {
       options.endpoint = 's3.amazonaws.com';
       options.region = 'us-standard';
     } else {
-      options.endpoint = options.region === 'us-standard' ?
-        's3.amazonaws.com' :
-        's3-' + options.region + '.amazonaws.com';
+      options.endpoint = 's3-' + options.region + '.amazonaws.com';
     }
 
     if (options.region !== 'us-standard') {

--- a/test/createClient.test.js
+++ b/test/createClient.test.js
@@ -261,6 +261,22 @@ describe('knox.createClient()', function () {
         assert.equal(client.url('file'), 'https://misc.s3.amazonaws.com/file');
       });
 
+      it('should derive endpoint correctly from explicit us-east-1 region', function () {
+        var client = knox.createClient({
+            key: 'foobar'
+          , secret: 'baz'
+          , bucket: 'misc'
+          , style: 'virtualHosted'
+          , region: 'us-east-1'
+        });
+
+        assert.equal(client.secure, true);
+        assert.equal(client.style, 'virtualHosted');
+        assert.equal(client.region, 'us-standard');
+        assert.equal(client.endpoint, 's3.amazonaws.com');
+        assert.equal(client.url('file'), 'https://misc.s3.amazonaws.com/file');
+      });
+
       it('should set secure to false and update the URL when given a port', function () {
         var client = knox.createClient({
             key: 'foobar'


### PR DESCRIPTION
s3-us-east-1.amazonaws.com has just stopped resolving.

According to http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region the correct endpoint to use with the us-east-1 region is s3.amazonaws.com.
