### PR TITLE
Fix issue with request errors causing Node to terminate

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -398,21 +398,9 @@ Client.prototype.putFile = function(src, filename, headers, fn){
 
     var stream = fs.createReadStream(src);
 
-    var fnCalled = false;
-    function wrappedFn(err, result) {
-      if (fnCalled) {
-        if (err) {
-          emitter.emit('error', err);
-        }
-      } else {
-        fnCalled = true;
-        fn(err, result);
-      }
-    }
-    var req = self.putStream(stream, filename, headers, wrappedFn);
+    var req = self.putStream(stream, filename, headers, fn);
 
     req.on('progress', emitter.emit.bind(emitter, 'progress'));
-    req.on('error', wrappedFn);
   });
 
   return emitter;


### PR DESCRIPTION
Removed extra installation of error handler for HTTP request in putFile.
Removed wrappedFn so that putFile has the same callback behavior as
putStream.
Making these changes completely eliminated a problem I was having with
request errors being forwarded to the "progress" emitter returned from
putFile and causing Node to terminate.
See discussion here:
https://github.com/LearnBoost/knox/issues/207
