### PR TITLE
add expect100Continue option

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -195,7 +195,7 @@ var Client = module.exports = exports = function Client(options) {
     throw new Error('Bucket name "' + options.bucket + '" ' + invalidness + '.');
   }
 
-  // Save original options, we will need them for Client#copyTo
+  // Save original options, we will need them for Client#copyTo and Client#put
   this.options = utils.merge({}, options);
 
   // Make sure we don't override options the user passes in.
@@ -324,9 +324,13 @@ Client.prototype.request = function(method, filename, headers){
  */
 
 Client.prototype.put = function(filename, headers){
-  headers = utils.merge({
-      Expect: '100-continue'
-  }, headers || {});
+  headers = utils.merge({}, headers || {});
+  if (this.options.expect100Continue) {
+    headers = utils.merge({
+        Expect: '100-continue'
+    }, headers || {});
+  }
+  
   return this.request('PUT', filename, headers);
 };
 


### PR DESCRIPTION
add expect100Continue option for Client#put
(options not to send "Expect: 100-continue" header)

I use the storage (not S3) that does not support "Expect: 100-continue".
I added expect100Continue option for CreateClient().
(default : expect100Continue = true)
