### PR TITLE
check url.query is object or not

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -205,11 +205,13 @@ exports.canonicalizeResource = function(resource){
     , buf = [];
 
   // apply the query string whitelist
-  Object.keys(url.query).forEach(function (key) {
+  if (url.query && typeof url.query === 'object') {
+    Object.keys(url.query).forEach(function (key) {
       if (whitelist.indexOf(key) != -1) {
-          buf.push(key + (url.query[key] ? "=" + url.query[key] : ''));
+        buf.push(key + (url.query[key] ? "=" + url.query[key] : ''));
       }
-  });
+    });
+  }
 
   return path + (buf.length
     ? '?' + buf.sort().join('&')


### PR DESCRIPTION
when `url.query` is `null`, skip whitelist check.

```
console.log(url); // knox/lib/auth.js#208~

{ protocol: null,
  slashes: null,
  auth: null,
  host: null,
  port: null,
  hostname: null,
  hash: null,
  search: null,
  query: null,
  pathname: '/media/sample.txt',
  path: '/media/sample.txt',
  href: '/media/sample.txt' }

TypeError: Object.keys called on non-object
  at Function.keys (native)
  at Object.exports.canonicalizeResource (node_modules/knox/lib/auth.js:209:10)
  at Client.request (node_modules/knox/lib/client.js:275:22)
  at Client.head (node_modules/knox/lib/client.js:586:15)
  at Client.headFile (node_modules/knox/lib/client.js:604:18)
  at lib/s3.coffee:17:14
  at Object.module.exports.head (lib/s3.coffee:16:9)
  at Object.<anonymous> (lib/s3.coffee:25:3)
  at Object.<anonymous> (lib/s3.coffee:3:1)
  at Module._compile (module.js:460:26)
  at Object.exports.run (/usr/local/var/nodebrew/node/v0.11.14/lib/node_modules/coffee-script/lib/coffee-script/coffee-script.js:119:23)
  at compileScript (/usr/local/var/nodebrew/node/v0.11.14/lib/node_modules/coffee-script/lib/coffee-script/command.js:207:29)
  at compilePath (/usr/local/var/nodebrew/node/v0.11.14/lib/node_modules/coffee-script/lib/coffee-script/command.js:160:14)
  at Object.exports.run (/usr/local/var/nodebrew/node/v0.11.14/lib/node_modules/coffee-script/lib/coffee-script/command.js:95:21)
  at Object.<anonymous> (/usr/local/var/nodebrew/node/v0.11.14/lib/node_modules/coffee-script/bin/coffee:7:41)
  at Module._compile (module.js:460:26)
  at Object.Module._extensions..js (module.js:478:10)
  at Module.load (module.js:355:32)
  at Function.Module._load (module.js:310:12)
  at Function.Module.runMain (module.js:501:10)
  at startup (node.js:124:16)
  at node.js:842:3
```
