### PR TITLE
make sure url.query exists

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -205,11 +205,13 @@ exports.canonicalizeResource = function(resource){
     , buf = [];
 
   // apply the query string whitelist
-  Object.keys(url.query).forEach(function (key) {
+  if (url.query) {
+    Object.keys(url.query).forEach(function (key) {
       if (whitelist.indexOf(key) != -1) {
           buf.push(key + (url.query[key] ? "=" + url.query[key] : ''));
       }
-  });
+    });
+  }
 
   return path + (buf.length
     ? '?' + buf.sort().join('&')


### PR DESCRIPTION
Sometimes `url.query` is null, this prevents from throwing error.
