### PR TITLE
allow accessKeyId & secretAccessKey

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -266,6 +266,15 @@ var userDataUrl = client.https('/user.json');
 Besides the required `key`, `secret`, and `bucket` options, you can supply any
 of the following:
 
+
+### `accessKeyId`
+
+Alias to `key`
+
+### `secretAccessKey`
+
+Alias to `secret`
+
 ### `endpoint`
 
 By default knox will send all requests to the global endpoint

--- a/lib/client.js
+++ b/lib/client.js
@@ -173,8 +173,8 @@ function getCopyHeaders(sourceBucket, sourceFilename, headers) {
  */
 
 var Client = module.exports = exports = function Client(options) {
-  if (!options.key) throw new Error('aws "key" required');
-  if (!options.secret) throw new Error('aws "secret" required');
+  if (!options.key && !options.accessKeyId ) throw new Error('aws "key" required');
+  if (!options.secret && !options.secretAccessKey) throw new Error('aws "secret" required');
   if (!options.bucket) throw new Error('aws "bucket" required');
 
   if (options.style && options.style !== 'virtualHosted' &&
@@ -191,6 +191,14 @@ var Client = module.exports = exports = function Client(options) {
 
   if (invalidness) {
     throw new Error('Bucket name "' + options.bucket + '" ' + invalidness + '.');
+  }
+
+  //overwrite for internal use, see official AWSJavaScriptSDK
+  if(options.accessKeyId) {
+      options.key = options.accessKeyId;
+  }
+  if(options.secretAccessKey) {
+      options.secret = options.secretAccessKey;
   }
 
   // Save original options, we will need them for Client#copyTo

--- a/test/createClient.test.js
+++ b/test/createClient.test.js
@@ -12,10 +12,24 @@ describe('knox.createClient()', function () {
       );
     });
 
+    it('should not ask for a key when accessKeyId is passed', function () {
+      assert.throws(
+        function () { knox.createClient({accessKeyId: 'foo'}); },
+        /aws "secret" required/
+      );
+    });
+
     it('should ask for a secret when only a key is passed', function () {
       assert.throws(
         function () { knox.createClient({ key: 'foo' }); },
         /aws "secret" required/
+      );
+    });
+
+    it('should not ask for a secret when secretAccessKey is passed', function () {
+      assert.throws(
+        function () { knox.createClient({ accessKeyId: 'foo', secretAccessKey: 'bar' }); },
+        /aws "bucket" required/
       );
     });
 
@@ -188,6 +202,18 @@ describe('knox.createClient()', function () {
       var client = knox.createClient({
           key: 'foobar'
         , secret: 'baz'
+        , bucket: 'misc'
+      });
+
+      assert.equal(client.key, 'foobar');
+      assert.equal(client.secret, 'baz');
+      assert.equal(client.bucket, 'misc');
+    });
+
+    it('should copy over alias properties', function () {
+      var client = knox.createClient({
+          accessKeyId: 'foobar'
+        , secretAccessKey: 'baz'
         , bucket: 'misc'
       });
 


### PR DESCRIPTION
allow accessKeyId as key and secretAccessKey as secret in opts (like
the official AWSJavaScriptSDK).
