### PR TITLE
Add support for using an HTTP proxy

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -23,7 +23,8 @@ var Emitter = require('events').EventEmitter
   , once = require('once')
   , xml2js = require('xml2js')
   , StreamCounter = require('stream-counter')
-  , qs = require('querystring');
+  , qs = require('querystring')
+  , HttpsProxyAgent = require('https-proxy-agent')
 
 // The max for multi-object delete, bucket listings, etc.
 var BUCKET_OPS_MAX = 1000;
@@ -284,6 +285,9 @@ Client.prototype.request = function(method, filename, headers){
   options.method = method;
   options.path = pathPrefix + fixedFilename;
   options.headers = headers;
+  if(process.env.https_proxy) {
+    options.agent = new HttpsProxyAgent(process.env.https_proxy);
+  }
   var req = (this.secure ? https : http).request(options);
   req.url = this.url(filename);
   debug('%s %s', method, req.url);

--- a/package.json
+++ b/package.json
@@ -21,11 +21,12 @@
   },
   "bugs": "https://github.com/LearnBoost/knox/issues",
   "dependencies": {
-    "mime": "*",
-    "xml2js": "^0.4.4",
     "debug": "^1.0.2",
+    "https-proxy-agent": "^1.0.0",
+    "mime": "*",
+    "once": "^1.3.0",
     "stream-counter": "^1.0.0",
-    "once": "^1.3.0"
+    "xml2js": "^0.4.4"
   },
   "devDependencies": {
     "mocha": "*"


### PR DESCRIPTION
When https_proxy environment variable is set configure knox to use an HTTP proxy server.