### PR TITLE
Upgrades xml2json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "bugs": "https://github.com/LearnBoost/knox/issues",
   "dependencies": {
     "mime": "*",
-    "xml2js": "^0.4.4",
+    "xml2js": ">=0.4.16",
     "debug": "^1.0.2",
     "stream-counter": "^1.0.0",
     "once": "^1.3.0"


### PR DESCRIPTION
Current version of xml2json breaks when lodash 4 coexists in a project, upgrading the version of this library to one that uses lodash 4 resolves the issue.