### PR TITLE
Added travis CI integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /test/auth.json
 /node_modules/
 /npm-debug.log
+/coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: node_js
+
+node_js:
+  - '0.10'
+  - '4'
+  - '6'
+
+before_script:
+  - ./test/travis/setUpTravis.sh > ./test/auth.json
+
+script:
+  - npm test
+
+env:
+  global:
+    - secure: LNtTrtAU/ssuJvf591LUJSK2Cuz+J0so91WnRgNZMfIH6cshyt+JusXXPpkaz73tn8U6zrjJoJ4kzGzKCOWixS4VhzdEaVnbEyJADXVA9F0hpI0ywlBSt/JKcPykm644HoXPYgd1q8BG4YiG+JKvz9kMLixWKKy/FaZJDg/XH+h0aEORxneu4W0PSJaY9nJJTf8eovg3mHHAKqJrXVYIxVlN5NT3pojVItQPEcEnvqzK1gIobxqS+SBaAsQXrPQ/v0m8ksTIylT8cLzppXhOHmO/31PZsvm0hXDsiYfkKPI9iDN1hISMn391ce/iEQQoDFWirjggrYb57uJNhek0NFUbtMDdf0XFKX2GmrelpONAZvlIJ+TU424HoekVq8Msv6Pp+hVkpAAsppGqEYK0HDyH3yT5WxZbrEKIGl/xYhfAPn1EQrPt+Xv9SQUfqqttR9uFmc9okqGmHxBkW1dCq1ChjRtqTDo2wOZlAGxpkPcfnad0gwNT+CfY0vtPmbLnM34lz7TlwdwP9xlBDOMyPKDu6OtdSKf6puz/0jXmIh7XdAxp8s+95Ig8qvGZaE2nu7HGdCkt5By691Fz19WtHQpqYhwTTNorJPHTUMpOBe+9f+mmQrvYDPXgQQ4EaGjEbYzl1Xv9YSckteJRnlYr4fLEYulP5BYQS4/W+s7bX4g=
+    - secure: T20xTA/DHhzrIKvrmZ0FRKUThdiKFfvlwR8o5Rniyid0hPe9bd6hb0d46MMXcsTwKpMb9465UoNAI9WbgZGld2+iaUdNuXTvVnVbRnUYI3o74ACpNaNQLiCB+ywR57XbBeoKFwPKRRTI4dil3VWkFq6hT+wGCNW/ZJnEOCEInR20xp9GNm3C/phOZdiwX6Bnxku9rcWmYaOmb/cnfLaXM2/EdlDORcmFXCDzoyYSmS9RjbCxjaqf/toqvNFxJSl6r/6ryBpgaDfgpBpbwXlDC/Ie/C33XKEiGjA2bw8TXSYVXgOgdJrGxM7exIh+mjrl7/2p+p9v+oTPJHOu6B/ml1zvluzPiz1v9dan4bAd9CRTgOmdeD3aeh56Q/HErCLO9bEPyMWKjVBqwhlrcOadz2eByIT7BdnLMkDMiXPR1O+1duOinEg6U9zX/vCLBCpnIlLGwN/AIQbsp4Gp89gqtxbC7bI4sB4TgcKKdbqAuRiHJ1CcybI4g0Py/zFjwXsrD/vh+8ukD5+JHx/3mTzZRCSZRe/EM/IyLeIRI/TbEB+ePJSKeyXLVdo7hfIyAxWwlwEyXlg2qfnJb3jylbdkFmpJ2/bbmDm93IXtcuhOmYKHqp2Lzt8mOloqoIm5As/Db5rP54xanImWGveWpw9RyKcANX8UivkX6dDKYvqCxrc=

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,25 @@ language: node_js
 node_js:
   - '0.10'
   - '4'
-  - '6'
+  - 'node'
+
+# Gives us faster boot time, see https://docs.travis-ci.com/user/ci-environment/
+sudo: false
 
 before_script:
   - ./test/travis/setUpTravis.sh > ./test/auth.json
 
 script:
   - npm test
+
+matrix:
+  include:
+    - node_js: 'node'
+      env: LCOV=true
+      script:
+        - npm run test_cov
+      after_script:
+        - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
 
 env:
   global:

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,7 @@
 # knox
 
 [![Build Status](https://travis-ci.org/Automattic/knox.svg?branch=master)](http://travis-ci.org/Automattic/knox)
+[![Coverage Status](https://coveralls.io/repos/github/Automattic/knox/badge.svg?branch=master)](https://coveralls.io/github/Automattic/knox?branch=master)
 
 Node Amazon S3 Client.
 
@@ -437,3 +438,14 @@ Then install the dev dependencies and execute the test suite:
 $ npm install
 $ npm test
 ```
+
+### Running coverage tests
+
+Execute:
+
+```
+$ npm install
+$ npm run test_cov
+```
+
+And navigate to _coverage/lcov-report/index.html_ to view HTML report.

--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,7 @@
 # knox
 
+[![Build Status](https://travis-ci.org/Automattic/knox.svg?branch=master)](http://travis-ci.org/Automattic/knox)
+
 Node Amazon S3 Client.
 
 ## Features

--- a/package.json
+++ b/package.json
@@ -28,10 +28,13 @@
     "once": "^1.3.0"
   },
   "devDependencies": {
+    "coveralls": "2.x",
+    "istanbul": "0.4.x",
     "mocha": "*"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "test_cov": "istanbul cover node_modules/mocha/bin/_mocha --report lcov"
   },
   "directories": {
     "lib": "./lib"

--- a/test/knox.test.js
+++ b/test/knox.test.js
@@ -570,7 +570,7 @@ function runTestsForStyle(style, userFriendlyName) {
         var req = client.request('POST', '/?delete', {
           'Content-Length': xml.length,
           'Content-MD5': crypto.createHash('md5').update(xml).digest('base64'),
-          'Accept:': '*\/*'
+          'Accept': '*\/*'
         })
         .on('error',done)
         .on('response', function (res) {

--- a/test/travis/setUpTravis.sh
+++ b/test/travis/setUpTravis.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+echo "{
+  \"key\": \"$AWS_KEY\",
+  \"secret\": \"$AWS_SECRET\",
+  \"bucket\": \"test-knox-bucket\",
+  \"bucket2\": \"test-knox-bucket2\",
+  \"bucketUsWest2\": \"test-knox-bucket-oregon\"
+}"


### PR DESCRIPTION
- [ ] Setup AWS S3 buckets for testing.
- [ ] Need to encode `AWS_KEY` and `AWS_SECRET` env vars using `travis encrypt` for the original repo, see https://docs.travis-ci.com/user/encryption-keys/
- [x] Need to point all badges to the main organization
- [ ] Need to enable builds on TravisCI for main organization and set concurrency to one job at a time (in Travis UI settings)

See https://travis-ci.org/Srokap/knox for the tests running on my fork.
See https://coveralls.io/github/Srokap/knox for how the coveralls integration looks like.

For testing I chose oldest branch I was able to run tests on (the 0.8 defined in package.json was failing on `npm install`), LTS and current version which is 6. For now we run them in series, so didn't want to add more than I felt was necessary. If we created separate buckets for them, they could run in parallel.
