### PR TITLE
Missing once wrappers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /test/auth.json
 /node_modules/
 /npm-debug.log
+.idea

--- a/lib/client.js
+++ b/lib/client.js
@@ -568,6 +568,7 @@ Client.prototype.getFile = function(filename, headers, fn){
   }
 
   var req = this.get(filename, headers);
+  fn = once(fn);
   registerReqListeners(req, fn);
   req.end();
   return req;
@@ -783,6 +784,7 @@ Client.prototype.list = function(params, headers, fn){
 
   var url = params ? '?' + qs.stringify(params) : '';
   var req = this.request('GET', url, headers);
+  fn = once(fn);
   registerReqListeners(req, function(err, res){
     if (err) return fn(err);
 


### PR DESCRIPTION
Some of the request types do not have the `once` wrappers that others do. Notably, we encountered an issue with `.list()` where certain errors, like `EHOSTUNREACH`, cause double callbacks.