### PR TITLE
chore(package): bump debug to 2.6.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "amazon",
     "s3"
   ],
-  "version": "0.9.2",
+  "version": "0.9.3",
   "author": "TJ Holowaychuk <tj@learnboost.com>",
   "contributors": [
     "TJ Holowaychuk <tj@learnboost.com>",
@@ -23,7 +23,7 @@
   "dependencies": {
     "mime": "*",
     "xml2js": "^0.4.4",
-    "debug": "^2.2.0",
+    "debug": "^2.6.7",
     "stream-counter": "^1.0.0",
     "once": "^1.3.0"
   },


### PR DESCRIPTION
prior to 2.6.7, `debug` pulls some known-to-be-vulnerable version of `ms`, according to Snyk https://snyk.io/test/npm/debug/2.6.6

Following up on https://github.com/Automattic/knox/pull/293, https://github.com/Automattic/knox/pull/300, https://github.com/Automattic/knox/pull/318