### PR TITLE
Ignore putStream content-length requirement when transfer-encoding is chunked

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -385,7 +385,6 @@ Client.prototype.putFile = function(src, filename, headers, fn){
 
 /**
  * PUT the given `stream` as `filename` with `headers`.
- * `headers` must contain `'Content-Length'` at least.
  *
  * @param {Stream} stream
  * @param {String} filename
@@ -397,7 +396,8 @@ Client.prototype.putFile = function(src, filename, headers, fn){
 
 Client.prototype.putStream = function(stream, filename, headers, fn){
   var contentLength = getHeader(headers, 'content-length');
-  if (contentLength === null) {
+  var transferEncoding = getHeader(headers, 'transfer-encoding');
+  if (contentLength === null && transferEncoding !== 'chunked') {
     process.nextTick(function () {
       fn(new Error('You must specify a Content-Length header.'));
     });


### PR DESCRIPTION
https://github.com/Automattic/knox/issues/322

@TooTallNate @rauchg 