### PR TITLE
specify mime version to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "bugs": "https://github.com/LearnBoost/knox/issues",
   "dependencies": {
-    "mime": "*",
+    "mime": "1.4.0",
     "xml2js": "^0.4.4",
     "debug": "^2.2.0",
     "stream-counter": "^1.0.0",


### PR DESCRIPTION
mime 2.0.0 have breaking changes. It requires node 6+ . We are specifying the version to 1.4.0.