### PR TITLE
Use mime@^1.4.1 for API compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "bugs": "https://github.com/LearnBoost/knox/issues",
   "dependencies": {
-    "mime": "*",
+    "mime": "^1.4.1",
     "xml2js": "^0.4.4",
     "debug": "^2.2.0",
     "stream-counter": "^1.0.0",


### PR DESCRIPTION
Since the release of [mime 2.0.0](https://github.com/broofa/node-mime/releases/tag/v2.0.0), the API has totally changed and the `mime.lookup()` function used in `knox` is not defined anymore.

This PR sets the version of mime to use in `package.json` to v1 to prevent errors due to these API breaking changes.