### PR TITLE
fix Sign for URLs containing spechial chars: !'()#*+? and non latin chars

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -854,7 +854,7 @@ Client.prototype.https = function(filename){
 
 Client.prototype.signedUrl = function(filename, expiration, options){
   var epoch = Math.floor(expiration.getTime()/1000)
-    , pathname = url.parse(filename).pathname
+    , pathname = url.parse(encodeSpecialCharacters(filename)).pathname
     , resource = '/' + this.bucket + ensureLeadingSlash(pathname);
 
   if (options && options.qs) {


### PR DESCRIPTION
Problem with get signed url to download file.

When file URL contains spechial chars, sign for it is created without converting these chars.
Also the same problem is with non latin chars.

So file url and it url in sign are different. Because of that sign is incorrect.
Issue: https://github.com/Automattic/knox/issues/334