### PR TITLE
fix: use mime@^1 to avoid mime.lookup issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "bugs": "https://github.com/LearnBoost/knox/issues",
   "dependencies": {
-    "mime": "*",
+    "mime": "^1",
     "xml2js": "^0.4.4",
     "debug": "^2.2.0",
     "stream-counter": "^1.0.0",


### PR DESCRIPTION
`mime@2` removed `lookup()` which is used in `knox` `putFile()`.

```
Version 2 is a breaking change from 1.x as the semver implies. Specifically:

    lookup() renamed to getType()
    extension() renamed to getExtension()
    charset() and load() methods have been removed
```